### PR TITLE
Bump GitHub Action pins to node24-compatible majors

### DIFF
--- a/.github/workflows/analyze-detekt.yml
+++ b/.github/workflows/analyze-detekt.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup detekt
       id: setup
       run: |

--- a/.github/workflows/release-xcframework.yml
+++ b/.github/workflows/release-xcframework.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -21,7 +21,7 @@ jobs:
           - os: windows-latest
             targets: native
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-unicode-data.yml
+++ b/.github/workflows/update-unicode-data.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_targets: common
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           java-version: '17'

--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
Bumps GitHub Action pins to majors that ship with the node24 runtime, ahead of GitHub's node20 deprecation.

- `actions/checkout` v4 → v6

Tracking: https://github.com/Doist/platform-backlog/issues/1385
